### PR TITLE
Fix function key mapping arithmetic that underflows.

### DIFF
--- a/src/keysym/mod.rs
+++ b/src/keysym/mod.rs
@@ -39,6 +39,9 @@ impl TryFrom<u32> for Keysym {
     type Error = anyhow::Error;
 
     fn try_from(value: u32) -> Result<Self, Self::Error> {
+        const XK_F1: u32 = 0xffbe;
+        const XK_F12: u32 = 0xffc9;
+
         match value {
             0xff08 => Ok(Backspace),
             0xff09 => Ok(Tab),
@@ -54,8 +57,8 @@ impl TryFrom<u32> for Keysym {
             0xff52 => Ok(Up),
             0xff53 => Ok(Right),
             0xff54 => Ok(Down),
-            f if (f >= 0xffbe && f <= 0xffc9) => {
-                let n = f - 0xffbf + 1;
+            f if (f >= XK_F1 && f <= XK_F12) => {
+                let n = f - XK_F1 + 1;
                 // TODO: handle cast
                 Ok(FunctionKey(n as u8))
             }


### PR DESCRIPTION
Pressing `F1` results in an underflow panic due to a copy-paste error in the `try_from` call that maps `u32` to a `Keysym`:
```
thread 'tokio-runtime-worker' panicked at 'attempt to subtract with overflow', src/keysym/mod.rs:58:25
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

I pulled the F1/F12 values out into constants for now. I'll move all of the keysym values to constants in another change.

After this change, I could successfully press `F1` on the example server:
```
[2022-04-29T22:31:16Z DEBUG rfb::server] Rx: KeyEvent=KeyEvent { is_pressed: true, key: FunctionKey(1) }
```