### PR TITLE
Move image dep to dev-dependencies as it's only used for the example.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,8 @@ async-trait = "0.1.53"
 bitflags = "1.3.2"
 env_logger = "0.9.0"
 futures = "0.3.21"
-image = "0.24.1"
 log = "0.4.14"
 tokio = { version = "1", features = ["full"] }
+
+[dev-dependencies]
+image = "0.24.1"


### PR DESCRIPTION
Building the `image` crate was the largest chunk (~12% of a clean debug propolis build) I saw while running `cargo build --timings` on propolis but it's only used for the example code.