### PR TITLE
Expand keysym values sufficiently to represent an AT keyboard.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ path = "examples/server.rs"
 
 [dependencies]
 anyhow = "1.0"
+ascii = { version = "1.0", default-features = false }
 async-trait = "0.1.53"
 bitflags = "1.3.2"
 env_logger = "0.9.0"

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -4,7 +4,7 @@
 //
 // Copyright 2022 Oxide Computer Company
 
-use anyhow::{anyhow, bail, Result};
+use anyhow::{bail, Result};
 use async_trait::async_trait;
 use clap::{Parser, ValueEnum};
 use env_logger;
@@ -13,7 +13,7 @@ use image::GenericImageView;
 use log::info;
 use rfb::encodings::RawEncoding;
 use rfb::rfb::{
-    FramebufferUpdate, PixelFormat, ProtoVersion, Rectangle, SecurityType, SecurityTypes,
+    FramebufferUpdate, KeyEvent, PixelFormat, ProtoVersion, Rectangle, SecurityType, SecurityTypes,
 };
 use rfb::{
     pixel_formats::rgb_888,
@@ -220,8 +220,18 @@ fn generate_pixels(img: Image, big_endian: bool, rgb_order: (u8, u8, u8)) -> Vec
 #[async_trait]
 impl Server for ExampleServer {
     async fn get_framebuffer_update(&self) -> FramebufferUpdate {
+        let pixels_width = 1024;
+        let pixels_height = 768;
         let pixels = generate_pixels(self.display, self.big_endian, self.rgb_order);
-        let r = Rectangle::new(0, 0, 1024, 768, Box::new(RawEncoding::new(pixels)));
+        let r = Rectangle::new(
+            0,
+            0,
+            pixels_width,
+            pixels_height,
+            Box::new(RawEncoding::new(pixels)),
+        );
         FramebufferUpdate::new(vec![r])
     }
+
+    async fn keyevent(&self, _ke: KeyEvent) {}
 }

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -233,5 +233,5 @@ impl Server for ExampleServer {
         FramebufferUpdate::new(vec![r])
     }
 
-    async fn keyevent(&self, _ke: KeyEvent) {}
+    async fn key_event(&self, _ke: KeyEvent) {}
 }

--- a/src/keysym.rs
+++ b/src/keysym.rs
@@ -4,12 +4,79 @@
 //
 // Copyright 2022 Oxide Computer Company
 
+use ascii::ToAsciiChar;
 use Keysym::*;
 
-#[derive(Debug)]
+// ascii characters have the same values as their keysym
+const ASCII_MAX: u32 = 0x7f;
+
+const KEYSYM_BACKSPACE: u32 = 0xff08;
+const KEYSYM_TAB: u32 = 0xff09;
+const KEYSYM_RETURN_ENTER: u32 = 0xff0d;
+const KEYSYM_ESCAPE: u32 = 0xff1b;
+const KEYSYM_INSERT: u32 = 0xff63;
+const KEYSYM_DELETE: u32 = 0xffff;
+const KEYSYM_HOME: u32 = 0xff50;
+const KEYSYM_END: u32 = 0xff57;
+const KEYSYM_PAGE_UP: u32 = 0xff55;
+const KEYSYM_PAGE_DOWN: u32 = 0xff56;
+const KEYSYM_PRINT: u32 = 0xff61;
+const KEYSYM_PAUSE: u32 = 0xff13;
+const KEYSYM_CAPS_LOCK: u32 = 0xffe5;
+const KEYSYM_SUPER_LEFT: u32 = 0xffeb;
+const KEYSYM_SUPER_RIGHT: u32 = 0xffec;
+const KEYSYM_MENU: u32 = 0xff67;
+
+const KEYSYM_LEFT: u32 = 0xff51;
+const KEYSYM_UP: u32 = 0xff52;
+const KEYSYM_RIGHT: u32 = 0xff53;
+const KEYSYM_DOWN: u32 = 0xff54;
+// function keys are in the range: 0xffbe to 0xffc9, in order
+const KEYSYM_F1: u32 = 0xffbe;
+const KEYSYM_F12: u32 = 0xffc9;
+const KEYSYM_SHIFT_LEFT: u32 = 0xffe1;
+const KEYSYM_SHIFT_RIGHT: u32 = 0xffe2;
+const KEYSYM_CTRL_LEFT: u32 = 0xffe3;
+const KEYSYM_CTRL_RIGHT: u32 = 0xffe4;
+
+// XXX(JPH): do we need to support meta keys?
+
+const KEYSYM_ALT_LEFT: u32 = 0xffe9;
+const KEYSYM_ALT_RIGHT: u32 = 0xffea;
+const KEYSYM_SCROLL_LOCK: u32 = 0xff14;
+const KEYSYM_NUM_LOCK: u32 = 0xff7f;
+
+const KEYSYM_KP_ENTER: u32 = 0xff8d;
+const KEYSYM_KP_SLASH: u32 = 0xffaf;
+const KEYSYM_KP_ASTERISK: u32 = 0xffaa;
+const KEYSYM_KP_MINUS: u32 = 0xffad;
+const KEYSYM_KP_PLUS: u32 = 0xffab;
+const KEYSYM_KP_7: u32 = 0xffb7;
+const KEYSYM_KP_HOME: u32 = 0xff95;
+const KEYSYM_KP_8: u32 = 0xffb8;
+const KEYSYM_KP_UP: u32 = 0xff97;
+const KEYSYM_KP_9: u32 = 0xffb9;
+const KEYSYM_KP_PGUP: u32 = 0xff9a;
+const KEYSYM_KP_4: u32 = 0xffb4;
+const KEYSYM_KP_LEFT: u32 = 0xff96;
+const KEYSYM_KP_5: u32 = 0xffb5;
+const KEYSYM_KP_EMPTY: u32 = 0xff9d;
+const KEYSYM_KP_6: u32 = 0xffb6;
+const KEYSYM_KP_RIGHT: u32 = 0xff98;
+const KEYSYM_KP_1: u32 = 0xffb1;
+const KEYSYM_KP_END: u32 = 0xff9c;
+const KEYSYM_KP_2: u32 = 0xffb2;
+const KEYSYM_KP_DOWN: u32 = 0xff99;
+const KEYSYM_KP_3: u32 = 0xffb3;
+const KEYSYM_KP_PGDOWN: u32 = 0xff9b;
+const KEYSYM_KP_0: u32 = 0xffb0;
+const KEYSYM_KP_INSERT: u32 = 0xff9e;
+const KEYSYM_KP_PERIOD: u32 = 0xffae;
+const KEYSYM_KP_DELETE: u32 = 0xff9f;
+
+#[derive(Debug, Copy, Clone)]
 pub enum Keysym {
-    Unknown(u32),
-    Utf32(char),
+    Ascii(ascii::AsciiChar),
     Backspace,
     Tab,
     ReturnOrEnter,
@@ -20,66 +87,141 @@ pub enum Keysym {
     End,
     PageUp,
     PageDown,
+    Print,
+    Pause,
+    CapsLock,
+
+    // "super" = windows/command key
+    SuperLeft,
+    SuperRight,
+
+    // usb-only
+    Menu,
+
     Left,
     Up,
     Right,
     Down,
+
     FunctionKey(u8),
+
     ShiftLeft,
     ShiftRight,
     ControlLeft,
     ControlRight,
-    MetaLeft,
-    MetaRight,
     AltLeft,
     AltRight,
+    ScrollLock,
+
+    // Number Keypad
+    NumLock,
+    KeypadSlash,
+    KeypadAsterisk,
+    KeypadMinus,
+    KeypadPlus,
+    KeypadEnter,
+    KeypadPeriod,
+    KeypadDelete,
+    Keypad0,
+    KeypadInsert,
+    Keypad1,
+    KeypadEnd,
+    Keypad2,
+    KeypadDown,
+    Keypad3,
+    KeypadPgDown,
+    Keypad4,
+    KeypadLeft,
+    Keypad5,
+    KeypadEmpty,
+    Keypad6,
+    KeypadRight,
+    Keypad7,
+    KeypadHome,
+    Keypad8,
+    KeypadUp,
+    Keypad9,
+    KeypadPgUp,
+
+    Unknown(u32),
 }
 
 impl TryFrom<u32> for Keysym {
     type Error = anyhow::Error;
 
     fn try_from(value: u32) -> Result<Self, Self::Error> {
-        const XK_F1: u32 = 0xffbe;
-        const XK_F12: u32 = 0xffc9;
-
         match value {
-            0xff08 => Ok(Backspace),
-            0xff09 => Ok(Tab),
-            0xff0d => Ok(ReturnOrEnter),
-            0xff1b => Ok(Escape),
-            0xff63 => Ok(Insert),
-            0xffff => Ok(Delete),
-            0xff50 => Ok(Home),
-            0xff57 => Ok(End),
-            0xff55 => Ok(PageUp),
-            0xff56 => Ok(PageDown),
-            0xff51 => Ok(Left),
-            0xff52 => Ok(Up),
-            0xff53 => Ok(Right),
-            0xff54 => Ok(Down),
-            f if (f >= XK_F1 && f <= XK_F12) => {
-                let n = f - XK_F1 + 1;
+            v if v <= ASCII_MAX => {
+                let ac = v.to_ascii_char().unwrap();
+                Ok(Ascii(ac))
+            }
+            KEYSYM_BACKSPACE => Ok(Backspace),
+            KEYSYM_TAB => Ok(Tab),
+            KEYSYM_RETURN_ENTER => Ok(ReturnOrEnter),
+            KEYSYM_ESCAPE => Ok(Escape),
+            KEYSYM_INSERT => Ok(Insert),
+            KEYSYM_DELETE => Ok(Delete),
+            KEYSYM_HOME => Ok(Home),
+            KEYSYM_END => Ok(End),
+            KEYSYM_PAGE_UP => Ok(PageUp),
+            KEYSYM_PRINT => Ok(Print),
+            KEYSYM_PAUSE => Ok(Pause),
+            KEYSYM_CAPS_LOCK => Ok(CapsLock),
+            KEYSYM_SUPER_LEFT => Ok(SuperLeft),
+            KEYSYM_SUPER_RIGHT => Ok(SuperRight),
+            KEYSYM_MENU => Ok(Menu),
+
+            KEYSYM_PAGE_DOWN => Ok(PageDown),
+            KEYSYM_LEFT => Ok(Left),
+            KEYSYM_UP => Ok(Up),
+            KEYSYM_RIGHT => Ok(Right),
+            KEYSYM_DOWN => Ok(Down),
+
+            f if (f >= KEYSYM_F1 && f <= KEYSYM_F12) => {
+                let n = f - KEYSYM_F1 + 1;
                 // TODO: handle cast
                 Ok(FunctionKey(n as u8))
             }
-            0xffe1 => Ok(ShiftLeft),
-            0xffe2 => Ok(ShiftRight),
-            0xffe3 => Ok(ControlLeft),
-            0xffe4 => Ok(ControlRight),
-            0xffe7 => Ok(MetaLeft),
-            0xffe8 => Ok(MetaRight),
-            0xffe9 => Ok(AltLeft),
-            0xffea => Ok(AltRight),
 
-            // TODO: figure out if there's a better way to map codes
-            other => {
-                let c = char::from_u32(other);
-                match c {
-                    // TODO: figure out what to do with these
-                    None => Ok(Unknown(other)),
-                    Some(v) => Ok(Utf32(v)),
-                }
-            }
+            KEYSYM_SHIFT_LEFT => Ok(ShiftLeft),
+            KEYSYM_SHIFT_RIGHT => Ok(ShiftRight),
+            KEYSYM_CTRL_LEFT => Ok(ControlLeft),
+            KEYSYM_CTRL_RIGHT => Ok(ControlRight),
+            KEYSYM_ALT_LEFT => Ok(AltLeft),
+            KEYSYM_ALT_RIGHT => Ok(AltRight),
+
+            KEYSYM_SCROLL_LOCK => Ok(ScrollLock),
+            KEYSYM_NUM_LOCK => Ok(NumLock),
+
+            KEYSYM_KP_ENTER => Ok(KeypadEnter),
+            KEYSYM_KP_SLASH => Ok(KeypadSlash),
+            KEYSYM_KP_ASTERISK => Ok(KeypadAsterisk),
+            KEYSYM_KP_MINUS => Ok(KeypadMinus),
+            KEYSYM_KP_PLUS => Ok(KeypadPlus),
+            KEYSYM_KP_7 => Ok(Keypad7),
+            KEYSYM_KP_HOME => Ok(KeypadHome),
+            KEYSYM_KP_8 => Ok(Keypad8),
+            KEYSYM_KP_UP => Ok(KeypadUp),
+            KEYSYM_KP_9 => Ok(Keypad9),
+            KEYSYM_KP_PGUP => Ok(KeypadPgUp),
+            KEYSYM_KP_4 => Ok(Keypad4),
+            KEYSYM_KP_LEFT => Ok(KeypadLeft),
+            KEYSYM_KP_5 => Ok(Keypad5),
+            KEYSYM_KP_EMPTY => Ok(KeypadEmpty),
+            KEYSYM_KP_6 => Ok(Keypad6),
+            KEYSYM_KP_RIGHT => Ok(KeypadRight),
+            KEYSYM_KP_1 => Ok(Keypad1),
+            KEYSYM_KP_END => Ok(KeypadEnd),
+            KEYSYM_KP_2 => Ok(Keypad2),
+            KEYSYM_KP_DOWN => Ok(KeypadDown),
+            KEYSYM_KP_3 => Ok(Keypad3),
+            KEYSYM_KP_PGDOWN => Ok(KeypadPgDown),
+            KEYSYM_KP_0 => Ok(Keypad0),
+            KEYSYM_KP_INSERT => Ok(KeypadInsert),
+            KEYSYM_KP_PERIOD => Ok(KeypadPeriod),
+            KEYSYM_KP_DELETE => Ok(KeypadDelete),
+
+            _ => Ok(Unknown(value)),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,7 @@
 // Copyright 2022 Oxide Computer Company
 
 pub mod encodings;
-mod keysym;
+pub mod keysym;
 pub mod pixel_formats;
 pub mod rfb;
 pub mod server;

--- a/src/rfb.rs
+++ b/src/rfb.rs
@@ -605,13 +605,13 @@ impl ReadMessage for ClientMessage {
                     // 2 bytes of padding
                     stream.read_u16().await?;
 
-                    let keysym_val = stream.read_u32().await?;
-                    let keysym = KeySym::try_from(keysym_val)?;
+                    let keysym_raw = stream.read_u32().await?;
+                    let keysym = KeySym::try_from(keysym_raw)?;
 
                     let key_event = KeyEvent {
                         is_pressed,
                         keysym,
-                        keysym_val,
+                        keysym_raw,
                     };
 
                     Ok(ClientMessage::KeyEvent(key_event))
@@ -657,9 +657,23 @@ pub struct FramebufferUpdateRequest {
 
 #[derive(Debug, Copy, Clone)]
 pub struct KeyEvent {
-    pub is_pressed: bool,
-    pub keysym: KeySym,
-    pub keysym_val: u32,
+    is_pressed: bool,
+    keysym: KeySym,
+    keysym_raw: u32,
+}
+
+impl KeyEvent {
+    pub fn keysym_raw(&self) -> u32 {
+        self.keysym_raw
+    }
+
+    pub fn keysym(&self) -> KeySym {
+        self.keysym
+    }
+
+    pub fn is_pressed(&self) -> bool {
+        self.is_pressed
+    }
 }
 
 bitflags! {

--- a/src/rfb.rs
+++ b/src/rfb.rs
@@ -12,7 +12,7 @@ use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::TcpStream;
 
 use crate::encodings::{Encoding, EncodingType};
-use crate::keysym::Keysym;
+use crate::keysym::KeySym;
 use crate::pixel_formats::rgb_888;
 
 pub trait ReadMessage {
@@ -606,7 +606,7 @@ impl ReadMessage for ClientMessage {
                     stream.read_u16().await?;
 
                     let keysym_val = stream.read_u32().await?;
-                    let keysym = Keysym::try_from(keysym_val)?;
+                    let keysym = KeySym::try_from(keysym_val)?;
 
                     let key_event = KeyEvent {
                         is_pressed,
@@ -656,10 +656,9 @@ pub struct FramebufferUpdateRequest {
 }
 
 #[derive(Debug, Copy, Clone)]
-#[allow(dead_code)]
 pub struct KeyEvent {
     pub is_pressed: bool,
-    pub keysym: Keysym,
+    pub keysym: KeySym,
     pub keysym_val: u32,
 }
 

--- a/src/rfb.rs
+++ b/src/rfb.rs
@@ -605,9 +605,14 @@ impl ReadMessage for ClientMessage {
                     // 2 bytes of padding
                     stream.read_u16().await?;
 
-                    let key = Keysym::try_from(stream.read_u32().await?)?;
+                    let keysym_val = stream.read_u32().await?;
+                    let keysym = Keysym::try_from(keysym_val)?;
 
-                    let key_event = KeyEvent { is_pressed, key };
+                    let key_event = KeyEvent {
+                        is_pressed,
+                        keysym,
+                        keysym_val,
+                    };
 
                     Ok(ClientMessage::KeyEvent(key_event))
                 }
@@ -650,11 +655,12 @@ pub struct FramebufferUpdateRequest {
     resolution: Resolution,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Copy, Clone)]
 #[allow(dead_code)]
 pub struct KeyEvent {
-    is_pressed: bool,
-    key: Keysym,
+    pub is_pressed: bool,
+    pub keysym: Keysym,
+    pub keysym_val: u32,
 }
 
 bitflags! {

--- a/src/server.rs
+++ b/src/server.rs
@@ -46,7 +46,7 @@ pub struct VncServer<S: Server> {
 #[async_trait]
 pub trait Server: Sync + Send + Clone + 'static {
     async fn get_framebuffer_update(&self) -> FramebufferUpdate;
-    async fn keyevent(&self, _ke: KeyEvent) {}
+    async fn key_event(&self, _ke: KeyEvent) {}
 }
 
 impl<S: Server> VncServer<S> {
@@ -205,7 +205,7 @@ impl<S: Server> VncServer<S> {
                     }
                     ClientMessage::KeyEvent(ke) => {
                         trace!("Rx [{:?}]: KeyEvent={:?}", addr, ke);
-                        self.server.keyevent(ke).await;
+                        self.server.key_event(ke).await;
                     }
                     ClientMessage::PointerEvent(pe) => {
                         trace!("Rx [{:?}: PointerEvent={:?}", addr, pe);


### PR DESCRIPTION
In support of https://github.com/oxidecomputer/propolis/pull/211, this PR expands the keysyms available from this crate.