### PR TITLE
Add typed errors and a method to stop the server.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,15 +19,16 @@ name = "example-server"
 path = "examples/server.rs"
 
 [dependencies]
-anyhow = "1.0"
 ascii = { version = "1.0", default-features = false }
 async-trait = "0.1.53"
 bitflags = "1.3.2"
 env_logger = "0.9.0"
 futures = "0.3.21"
 log = "0.4.17"
+thiserror = "1.0"
 tokio = { version = "1", features = ["full"] }
 
 [dev-dependencies]
+anyhow = "1.0"
 clap = { version = "3.2.5", features = ["derive"] }
 image = "0.24.1"

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -118,7 +118,7 @@ async fn main() -> Result<()> {
         big_endian: args.big_endian,
     };
     let s = VncServer::new(server, config, data);
-    s.start().await;
+    s.start().await?;
 
     Ok(())
 }

--- a/src/encodings.rs
+++ b/src/encodings.rs
@@ -8,7 +8,6 @@ use crate::{
     pixel_formats::rgb_888,
     rfb::{PixelFormat, Position, Resolution},
 };
-use anyhow::Result;
 
 use EncodingType::*;
 
@@ -65,25 +64,23 @@ impl From<EncodingType> for i32 {
     }
 }
 
-impl TryFrom<i32> for EncodingType {
-    type Error = anyhow::Error;
-
-    fn try_from(value: i32) -> Result<Self, Self::Error> {
+impl From<i32> for EncodingType {
+    fn from(value: i32) -> Self {
         match value {
-            0 => Ok(Raw),
-            1 => Ok(CopyRect),
-            2 => Ok(RRE),
-            5 => Ok(Hextile),
-            15 => Ok(TRLE),
-            16 => Ok(ZRLE),
-            -239 => Ok(CursorPseudo),
-            -223 => Ok(DesktopSizePseudo),
-            22 => Ok(JRLE),
-            24 => Ok(ZRLE2),
-            21 => Ok(JPEG),
-            6 => Ok(Zlib),
-            -314 => Ok(CursorWithAlpha),
-            v => Ok(EncodingType::Other(v)),
+            0 => Raw,
+            1 => CopyRect,
+            2 => RRE,
+            5 => Hextile,
+            15 => TRLE,
+            16 => ZRLE,
+            -239 => CursorPseudo,
+            -223 => DesktopSizePseudo,
+            22 => JRLE,
+            24 => ZRLE2,
+            21 => JPEG,
+            6 => Zlib,
+            -314 => CursorWithAlpha,
+            v => EncodingType::Other(v),
         }
     }
 }

--- a/src/pixel_formats.rs
+++ b/src/pixel_formats.rs
@@ -53,6 +53,12 @@
 //! - blue = pixel\[1\] & 255 = 0x03
 //!
 
+#[derive(Debug, thiserror::Error)]
+pub enum PixelFormatError {
+    #[error("unsupported or unknown fourcc: 0x{0:x}")]
+    UnsupportedFourCc(u32),
+}
+
 ///  Utility functions and constants related to fourcc codes.
 ///
 /// Fourcc is a 4-byte ASCII code representing a pixel format. For example, the value
@@ -62,9 +68,8 @@
 /// A good reference for mapping common fourcc codes to their corresponding pixel formats is the
 /// drm_fourcc.h header file in the linux source code.
 pub mod fourcc {
-    use super::rgb_888;
+    use super::{rgb_888, PixelFormatError};
     use crate::rfb::{ColorFormat, ColorSpecification, PixelFormat};
-    use anyhow::{anyhow, Result};
 
     // XXX: it might make sense to turn fourcc values into a type (such as an enum or collection of
     // enums)
@@ -73,7 +78,7 @@ pub mod fourcc {
     pub const FOURCC_BX24: u32 = 0x34325842; // little-endian BGRx, 8:8:8:8
     pub const FOURCC_XB24: u32 = 0x34324258; // little-endian xBGR, 8:8:8:8
 
-    pub fn fourcc_to_pixel_format(fourcc: u32) -> Result<PixelFormat> {
+    pub fn fourcc_to_pixel_format(fourcc: u32) -> Result<PixelFormat, PixelFormatError> {
         match fourcc {
             // little-endian xRGB
             FOURCC_XR24 => Ok(PixelFormat {
@@ -135,7 +140,7 @@ pub mod fourcc {
                 }),
             }),
 
-            v => Err(anyhow!("unknown fourcc: {}", v)),
+            v => Err(PixelFormatError::UnsupportedFourCc(v)),
         }
     }
 }


### PR DESCRIPTION
Since `anyhow` is generally recommended moreso for applications than libraries, I swapped over the uses to typed errors with `thiserror`.

Also added a `stop` method on `VncServer` to signal to a running server that it should no longer accept any new clients and disconnect any existing ones. There's also a corresponding `stop` method on the `Server` trait so that it may perform any needed cleanup on stop.